### PR TITLE
fix(docker): update CMD to include --no-group for jupyter execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,7 @@ COPY pyproject.toml uv.lock .python-version ./
 # Install the dependencies
 ENV PATH="/root/.local/bin:$PATH"
 RUN mkdir .db && \
-    uv python pin "$(cat .python-version)" && \
-    uv sync --no-group jupyter
+    uv python pin "$(cat .python-version)"
 
 # Verify the presence of the .git directory
 CMD [ "uv", "run","--no-group", "jupyter", "hikarie_bot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ RUN mkdir .db && \
     uv sync --no-group jupyter
 
 # Verify the presence of the .git directory
-CMD [ "uv", "run", "hikarie_bot"]
+CMD [ "uv", "run","--no-group", "jupyter", "hikarie_bot"]

--- a/hikarie_bot/_version.py
+++ b/hikarie_bot/_version.py
@@ -17,5 +17,5 @@ __version__: str
 __version_tuple__: VERSION_TUPLE
 version_tuple: VERSION_TUPLE
 
-__version__ = version = '0.1.dev169+g64fc962.d20250430'
-__version_tuple__ = version_tuple = (0, 1, 'dev169', 'g64fc962.d20250430')
+__version__ = version = '0.1.dev171+g1afcac1.d20250430'
+__version_tuple__ = version_tuple = (0, 1, 'dev171', 'g1afcac1.d20250430')


### PR DESCRIPTION
Updated the CMD instruction in the Dockerfile to ensure jupyter runs with the --no-group option, improving compatibility and execution behavior.