### PR TITLE
Fix: Correct new achievement logic to use initially_acquired_datetime

### DIFF
--- a/hikarie_bot/_version.py
+++ b/hikarie_bot/_version.py
@@ -17,5 +17,5 @@ __version__: str
 __version_tuple__: VERSION_TUPLE
 version_tuple: VERSION_TUPLE
 
-__version__ = version = '0.1.dev172+g3e7860e.d20250501'
-__version_tuple__ = version_tuple = (0, 1, 'dev172', 'g3e7860e.d20250501')
+__version__ = version = '0.1.dev2+g7c4a064'
+__version_tuple__ = version_tuple = (0, 1, 'dev2', 'g7c4a064')

--- a/hikarie_bot/_version.py
+++ b/hikarie_bot/_version.py
@@ -17,5 +17,5 @@ __version__: str
 __version_tuple__: VERSION_TUPLE
 version_tuple: VERSION_TUPLE
 
-__version__ = version = '0.1.dev2+g76fbab8.d20250602'
-__version_tuple__ = version_tuple = (0, 1, 'dev2', 'g76fbab8.d20250602')
+__version__ = version = '0.1.dev175+g52c5e52.d20250602'
+__version_tuple__ = version_tuple = (0, 1, 'dev175', 'g52c5e52.d20250602')

--- a/hikarie_bot/_version.py
+++ b/hikarie_bot/_version.py
@@ -17,5 +17,5 @@ __version__: str
 __version_tuple__: VERSION_TUPLE
 version_tuple: VERSION_TUPLE
 
-__version__ = version = '0.1.dev2+g7c4a064'
-__version_tuple__ = version_tuple = (0, 1, 'dev2', 'g7c4a064')
+__version__ = version = '0.1.dev2+g76fbab8.d20250602'
+__version_tuple__ = version_tuple = (0, 1, 'dev2', 'g76fbab8.d20250602')

--- a/hikarie_bot/modals.py
+++ b/hikarie_bot/modals.py
@@ -735,31 +735,31 @@ class WeeklyMessage(BaseMessage):
     ) -> list[UserAchievement]:
         """Get new achievements during the given date range."""
         # Get unique badge achievements in the date range
-        achievements = (
+        user_badges = (
             session.query(
-                Achievement.user_id,
-                Achievement.badge_id,
+                UserBadge.user_id,
+                UserBadge.badge_id,
                 Badge.message,
-                Achievement.achieved_time,
+                UserBadge.initially_acquired_datetime,
             )
-            .join(Badge, Achievement.badge_id == Badge.id)
+            .join(Badge, UserBadge.badge_id == Badge.id)
             .filter(
-                Achievement.achieved_time >= start_date,
-                Achievement.achieved_time <= end_date,
+                UserBadge.initially_acquired_datetime >= start_date,
+                UserBadge.initially_acquired_datetime <= end_date,
             )
-            .order_by(Achievement.achieved_time.desc())
+            .order_by(UserBadge.initially_acquired_datetime.desc())
             .limit(5)
             .all()
         )
 
         return [
             UserAchievement(
-                user_id=achievement.user_id,
-                badge_id=achievement.badge_id,
-                message=achievement.message,
-                achieved_time=achievement.achieved_time,
+                user_id=user_badge.user_id,
+                badge_id=user_badge.badge_id,
+                message=user_badge.message,
+                achieved_time=user_badge.initially_acquired_datetime,
             )
-            for achievement in achievements
+            for user_badge in user_badges
         ]
 
     def _get_most_acquired_badge(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,12 @@
 from collections.abc import Generator
-from typing import Any, Self
+import sys # Added sys import
+
+# Conditionally import Self and Any
+if sys.version_info >= (3, 11):
+    from typing import Self, Any
+else:
+    from typing_extensions import Self
+    from typing import Any # Any is available in typing for older versions too
 
 import pytest
 from sqlalchemy import create_engine

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,5 @@
 from collections.abc import Generator
-import sys # Added sys import
-
-# Conditionally import Self and Any
-if sys.version_info >= (3, 11):
-    from typing import Self, Any
-else:
-    from typing_extensions import Self
-    from typing import Any # Any is available in typing for older versions too
+from typing import Any, Self
 
 import pytest
 from sqlalchemy import create_engine

--- a/tests/test_modals.py
+++ b/tests/test_modals.py
@@ -1,5 +1,5 @@
 import zoneinfo
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta # Added timedelta
 from textwrap import dedent
 from unittest import mock
 
@@ -13,10 +13,10 @@ from hikarie_bot.modals import (
     InitialMessage,
     PointGetMessage,
     RegistryMessage,
-    WeeklyMessage,  # Added WeeklyMessage
-    UserAchievement,  # Added UserAchievement
+    WeeklyMessage,      # Added WeeklyMessage
+    UserAchievement,    # Added UserAchievement
 )
-from hikarie_bot.models import User, Badge, UserBadge  # Added User, Badge, UserBadge
+from hikarie_bot.models import User, Badge, UserBadge # Added User, Badge, UserBadge
 
 
 def test_initial_message() -> None:
@@ -344,18 +344,11 @@ def test_achievement_message_type_6(temp_db: sessionmaker[Session]) -> None:
         user_id="test_user",
     )
 
-    # The expected output will depend on the badge data for type 6.
-    # We expect a section for badge type 6, and context blocks for its badges.
-    # Since badge data is seeded by initially_insert_badge_data, we expect at least the section header and badge type 6 description.
-    # The badge images will be "not achieved" unless test_user has a badge of type 6.
-
     rendered = message.render()
-    # Check that only badge type 6 is present in the output
     badge_type_sections = [
         block for block in rendered if block.get("type") == "section" and "*6*" in block.get("text", {}).get("text", "")
     ]
     assert badge_type_sections, "Badge type 6 section should be present"
-    # There should be no badge type 1 section
     badge_type_1_sections = [
         block for block in rendered if block.get("type") == "section" and "*1*" in block.get("text", {}).get("text", "")
     ]
@@ -365,19 +358,16 @@ def test_achievement_message_type_6(temp_db: sessionmaker[Session]) -> None:
 @mock.patch("hikarie_bot.modals.BADGE_TYPES_TO_CHECK", [6])
 def test_achievement_message_6xx_taken_logic(temp_db: sessionmaker[Session]) -> None:
     """Test 6XX badge logic: taken icon if any user has it, not achieved if none."""
-    from hikarie_bot.models import Badge, UserBadge
+    from hikarie_bot.models import Badge, UserBadge # Local import for this test
 
     session = temp_db()
     initially_insert_badge_data(session=session)
 
-    # Find a badge with id in 600-699 and type 6
     badge_6xx = session.query(Badge).filter(Badge.badge_type_id == 6, Badge.id >= 600, Badge.id < 700).first()
     assert badge_6xx is not None, "Test requires a 6XX badge of type 6"
 
-    # Case 1: No user has the badge
     message = AchievementMessage(session=session, user_id="test_user")
     rendered = message.render()
-    # Find the context block for this badge
     found = False
     for block in rendered:
         if block.get("type") == "context":
@@ -385,18 +375,15 @@ def test_achievement_message_6xx_taken_logic(temp_db: sessionmaker[Session]) -> 
                 if element.get("type") == "image" and element.get("alt_text", "").startswith(
                     f"【{badge_6xx.message}】"
                 ):
-                    # Should be NOT_ACHIEVED_BADGE_IMAGE_URL
                     from hikarie_bot.constants import NOT_ACHIEVED_BADGE_IMAGE_URL
-
                     assert element["image_url"] == NOT_ACHIEVED_BADGE_IMAGE_URL
                     found = True
     assert found, "Should find not achieved icon for 6XX badge when no user has it"
 
-    # Case 2: Another user has the badge
     session.add(
         UserBadge(
             user_id="other_user",
-            user_info_raw_id="other_user", # Assuming user_info_raw_id can be same as user_id for simplicity
+            user_info_raw_id="other_user",
             badge_id=badge_6xx.id,
             initially_acquired_datetime=datetime(2024, 1, 1, 8, 0, 0, tzinfo=zoneinfo.ZoneInfo("Asia/Tokyo")),
             count=1,
@@ -414,7 +401,6 @@ def test_achievement_message_6xx_taken_logic(temp_db: sessionmaker[Session]) -> 
                     f"【{badge_6xx.message}】"
                 ):
                     from hikarie_bot.constants import TAKEN_6XX_BADGE_IMAGE_URL
-
                     assert element["image_url"] == TAKEN_6XX_BADGE_IMAGE_URL
                     found = True
     assert found, "Should find taken icon for 6XX badge when another user has it"
@@ -423,151 +409,121 @@ def test_achievement_message_6xx_taken_logic(temp_db: sessionmaker[Session]) -> 
 def test_get_new_achievements(temp_db: sessionmaker[Session]) -> None:
     """Test the _get_new_achievements method of WeeklyMessage."""
     session = temp_db()
-    initially_insert_badge_data(session=session) # Seed initial badge types and badges
+    initially_insert_badge_data(session=session)
 
-    # Define date range for the test
-    # Using timezone-aware datetimes as in other tests
     tokyo_tz = zoneinfo.ZoneInfo("Asia/Tokyo")
-    report_date = datetime(2024, 7, 7, 0, 0, 0, tzinfo=tokyo_tz) # A Sunday
-    start_of_week = report_date - timedelta(days=7) # Previous Sunday
-    end_of_week = report_date - timedelta(microseconds=1) # End of Saturday
+    report_date = datetime(2024, 7, 7, 0, 0, 0, tzinfo=tokyo_tz)
+    start_of_week = report_date - timedelta(days=7)
+    end_of_week = report_date - timedelta(microseconds=1)
 
-    # Create Users
     default_user_params = {
-        "level": 1,
-        "level_name": "Test Level 1",
-        "level_uped": False,
-        "point_to_next_level": 100,
-        "point_range_to_next_level": 200,
-        "current_level_point": 50,
+        "level": 1, "level_name": "Test Level 1", "level_uped": False,
+        "point_to_next_level": 100, "point_range_to_next_level": 200, "current_level_point": 50,
     }
     user1 = User(id="user1", current_score=100, previous_score=50, update_datetime=report_date, **default_user_params)
     user2 = User(id="user2", current_score=200, previous_score=150, update_datetime=report_date, **default_user_params)
     session.add_all([user1, user2])
-    session.commit() # Users must exist before UserBadge references them
+    session.commit()
 
-    # Create Badges (ensure some exist, or use ones from initially_insert_badge_data)
-    # Using high badge IDs to avoid conflicts with initially_insert_badge_data
     test_badge_ids = [5001, 5002, 5003, 5004, 5005, 5006, 5007]
     badges_to_add = []
-    for i, bid in enumerate(test_badge_ids):
+    for bid in test_badge_ids:
         badges_to_add.append(
             Badge(id=bid, badge_type_id=1, message=f"Message for Badge {bid}", condition=f"Cond {bid}", score=10, level=1)
         )
     session.add_all(badges_to_add)
     session.commit()
 
-    # Create UserBadge records
-    # These should be returned
-    ub1_time = start_of_week + timedelta(days=1) # Within week
+    ub1_time = start_of_week + timedelta(days=1)
     ub1 = UserBadge(user_id="user1", user_info_raw_id="user1_raw1", badge_id=test_badge_ids[0], initially_acquired_datetime=ub1_time, last_acquired_datetime=ub1_time, count=1)
-    ub2_time = start_of_week + timedelta(days=2) # Within week, later than ub1
+    ub2_time = start_of_week + timedelta(days=2)
     ub2 = UserBadge(user_id="user2", user_info_raw_id="user2_raw1", badge_id=test_badge_ids[1], initially_acquired_datetime=ub2_time, last_acquired_datetime=ub2_time, count=1)
 
-    # These should NOT be returned
-    ub3_time = start_of_week - timedelta(days=1) # Before week
+    ub3_time = start_of_week - timedelta(days=1)
     ub3 = UserBadge(user_id="user1", user_info_raw_id="user1_raw2", badge_id=test_badge_ids[2], initially_acquired_datetime=ub3_time, last_acquired_datetime=ub3_time, count=1)
-    ub4_time = end_of_week + timedelta(days=1) # After week
-    # Using test_badge_ids[0] for ub4 to check if it's correctly excluded even if badge_id is same as a valid one for another user
+    ub4_time = end_of_week + timedelta(days=1)
     ub4 = UserBadge(user_id="user2", user_info_raw_id="user2_raw2", badge_id=test_badge_ids[0], initially_acquired_datetime=ub4_time, last_acquired_datetime=ub4_time, count=1)
 
-    # Test `initially_acquired_datetime` logic vs `last_acquired_datetime`
-    ub5_initial_time = start_of_week - timedelta(days=5) # Initial acquire before week
-    ub5_last_time = start_of_week + timedelta(days=3)    # Last acquire within week
+    ub5_initial_time = start_of_week - timedelta(days=5)
+    ub5_last_time = start_of_week + timedelta(days=3)
     ub5 = UserBadge(user_id="user1", user_info_raw_id="user1_raw3", badge_id=test_badge_ids[3], initially_acquired_datetime=ub5_initial_time, last_acquired_datetime=ub5_last_time, count=2)
 
-    # More UserBadges to test limit and ordering
-    # ub1 and ub2 are already defined using test_badge_ids[0] and test_badge_ids[1]
-    # Let's use remaining test_badge_ids for the limit test items.
-    # We need 7 candidates in total to test the limit of 5.
-    # ub1 and ub2 are 2 candidates. We need 5 more.
-
-    user_badges_to_add = [ub1, ub2, ub3, ub4, ub5] # ub1, ub2 are candidates; ub3, ub4, ub5 are not.
-
-    # 7 items that *should* be candidates if not for the limit
+    user_badges_to_add = [ub1, ub2, ub3, ub4, ub5]
     candidate_user_badges = []
-    # We already have ub1 (day 1) and ub2 (day 2) as candidates.
-    # Add 5 more candidates to have a total of 7.
-    # These will use test_badge_ids[2] through test_badge_ids[6]
 
-    # Candidate 1: ub1 (day 1, badge 5001)
-    # Candidate 2: ub2 (day 2, badge 5002)
-
-    # Candidate 3 (day 0, badge 5003) - should be earliest if included in sorting
     cand3_time = start_of_week + timedelta(days=0, hours=12)
     cand3 = UserBadge(user_id="user1", user_info_raw_id="user1_cand3", badge_id=test_badge_ids[2], initially_acquired_datetime=cand3_time, count=1)
     candidate_user_badges.append(cand3)
-
-    # Candidate 4 (day 3, badge 5004)
     cand4_time = start_of_week + timedelta(days=3, hours=12)
     cand4 = UserBadge(user_id="user2", user_info_raw_id="user2_cand4", badge_id=test_badge_ids[3], initially_acquired_datetime=cand4_time, count=1)
     candidate_user_badges.append(cand4)
-
-    # Candidate 5 (day 4, badge 5005)
     cand5_time = start_of_week + timedelta(days=4, hours=12)
     cand5 = UserBadge(user_id="user1", user_info_raw_id="user1_cand5", badge_id=test_badge_ids[4], initially_acquired_datetime=cand5_time, count=1)
     candidate_user_badges.append(cand5)
-
-    # Candidate 6 (day 5, badge 5006)
     cand6_time = start_of_week + timedelta(days=5, hours=12)
     cand6 = UserBadge(user_id="user2", user_info_raw_id="user2_cand6", badge_id=test_badge_ids[5], initially_acquired_datetime=cand6_time, count=1)
     candidate_user_badges.append(cand6)
-
-    # Candidate 7 (day 6, badge 5007) - should be latest
     cand7_time = start_of_week + timedelta(days=6, hours=12)
     cand7 = UserBadge(user_id="user1", user_info_raw_id="user1_cand7", badge_id=test_badge_ids[6], initially_acquired_datetime=cand7_time, count=1)
     candidate_user_badges.append(cand7)
 
-    # Add ub1, ub2 to candidate_user_badges list for sorting later
     candidate_user_badges.extend([ub1, ub2])
-
     user_badges_to_add.extend([cand3, cand4, cand5, cand6, cand7])
     session.add_all(user_badges_to_add)
     session.commit()
 
-    # Instantiate WeeklyMessage
-    # Note: WeeklyMessage constructor calls _get_new_achievements itself.
-    # For isolated testing, we might call it directly, but here we test integration.
     weekly_message = WeeklyMessage(session=session, report_date=report_date)
-
-    # Call the method (it's also called in __init__, but we can call again for clarity or specific params)
     new_achievements = weekly_message._get_new_achievements(session, start_of_week, end_of_week)
 
-    # Assertions
     assert len(new_achievements) == 5, "Should return 5 achievements due to limit"
+
+    utc_zone = zoneinfo.ZoneInfo("UTC") # Define UTC zone for convenience
 
     for ach in new_achievements:
         assert isinstance(ach, UserAchievement), "All items should be UserAchievement instances"
-        # Make ach.achieved_time offset-aware for comparison if it's naive
-        # Assuming ach.achieved_time from DB is naive but represents Tokyo time
-        achieved_time_aware = ach.achieved_time.replace(tzinfo=tokyo_tz)
-        assert start_of_week <= achieved_time_aware <= end_of_week, "Achievement time should be within the week"
+        ach_time_to_compare = ach.achieved_time # This is naive UTC from DB
+        if ach_time_to_compare.tzinfo is None: # Should always be naive
+            ach_time_utc_aware = ach_time_to_compare.replace(tzinfo=utc_zone)
+            ach_time_to_compare = ach_time_utc_aware.astimezone(tokyo_tz)
+        else: # Should not happen based on current _get_new_achievements logic
+            ach_time_to_compare = ach_time_to_compare.astimezone(tokyo_tz)
 
-    # Check sorting (descending by achieved_time)
+        assert start_of_week <= ach_time_to_compare <= end_of_week, \
+            f"Achievement time {ach_time_to_compare} (original: {ach.achieved_time}) should be within the week [{start_of_week}, {end_of_week}]"
+
     for i in range(len(new_achievements) - 1):
         assert new_achievements[i].achieved_time >= new_achievements[i+1].achieved_time, "Achievements should be sorted descending by time"
 
-    # Check specific items that should NOT be there
     returned_tuples = {(ach.user_id, ach.badge_id) for ach in new_achievements}
-    # ub3 was badge_id=test_badge_ids[2] (5003)
     assert ("user1", test_badge_ids[2]) not in returned_tuples or \
-           any(ach.user_id == "user1" and ach.badge_id == test_badge_ids[2] and ach.achieved_time == cand3_time for ach in new_achievements), \
+           any(ach.user_id == "user1" and ach.badge_id == test_badge_ids[2] and (ach.achieved_time.replace(tzinfo=utc_zone).astimezone(tokyo_tz) if ach.achieved_time.tzinfo is None else ach.achieved_time.astimezone(tokyo_tz)) == cand3_time for ach in new_achievements), \
            "ub3 (before week) should not be returned unless it's the valid cand3"
-
-    # ub4 was badge_id=test_badge_ids[0] (5001) with user2, time after week
-    assert not any(ach.user_id == "user2" and ach.badge_id == test_badge_ids[0] and ach.achieved_time == ub4_time for ach in new_achievements), \
+    assert not any(ach.user_id == "user2" and ach.badge_id == test_badge_ids[0] and (ach.achieved_time.replace(tzinfo=utc_zone).astimezone(tokyo_tz) if ach.achieved_time.tzinfo is None else ach.achieved_time.astimezone(tokyo_tz)) == ub4_time for ach in new_achievements), \
            "ub4 (after week) should not be returned"
-
-    # ub5 was badge_id=test_badge_ids[3] (5004) with initial acquire before week
-    assert not any(ach.user_id == "user1" and ach.badge_id == test_badge_ids[3] and ach.achieved_time == ub5_initial_time for ach in new_achievements), \
+    assert not any(ach.user_id == "user1" and ach.badge_id == test_badge_ids[3] and (ach.achieved_time.replace(tzinfo=utc_zone).astimezone(tokyo_tz) if ach.achieved_time.tzinfo is None else ach.achieved_time.astimezone(tokyo_tz)) == ub5_initial_time for ach in new_achievements), \
            "ub5 (initial acquire before week) should not be returned"
 
+    filtered_candidates = []
+    # utc_zone is defined above in the first loop
+    for ub in candidate_user_badges:
+        # Assume ub.initially_acquired_datetime might have been converted to naive UTC by SQLAlchemy upon assignment
+        dt_potentially_naive_utc = ub.initially_acquired_datetime
 
-    # Check that the top 5 by initially_acquired_datetime are returned
-    # These are the last 5 from `candidate_badges` as they have the latest times
+        if dt_potentially_naive_utc.tzinfo is None:
+            dt_aware_utc = dt_potentially_naive_utc.replace(tzinfo=utc_zone)
+        else: # If it's somehow already aware, ensure it's UTC before converting to Tokyo
+            dt_aware_utc = dt_potentially_naive_utc.astimezone(utc_zone)
+
+        dt_tokyo_aware = dt_aware_utc.astimezone(tokyo_tz)
+
+        if start_of_week <= dt_tokyo_aware <= end_of_week:
+            filtered_candidates.append(ub)
+
     all_candidates_in_week = sorted(
-        [ub for ub in candidate_user_badges if start_of_week <= ub.initially_acquired_datetime <= end_of_week],
-        key=lambda x: x.initially_acquired_datetime,
+        filtered_candidates,
+        key=lambda x: (x.initially_acquired_datetime.replace(tzinfo=utc_zone).astimezone(tokyo_tz)
+                       if x.initially_acquired_datetime.tzinfo is None
+                       else x.initially_acquired_datetime.astimezone(tokyo_tz)),
         reverse=True
     )
     expected_top_5_source = all_candidates_in_week[:5]
@@ -578,11 +534,29 @@ def test_get_new_achievements(temp_db: sessionmaker[Session]) -> None:
 
         assert actual_ua.user_id == expected_ua_source.user_id
         assert actual_ua.badge_id == expected_ua_source.badge_id
-        # Query badge message for verification, as it's not in UserBadge directly
-        badge_msg_obj = session.get(Badge, expected_ua_source.badge_id) # Get existing badge
+
+        badge_msg_obj = session.get(Badge, expected_ua_source.badge_id)
         assert badge_msg_obj is not None
         assert actual_ua.message == badge_msg_obj.message
-        assert actual_ua.achieved_time == expected_ua_source.initially_acquired_datetime
+
+        # Convert expected datetime (from UserBadge Python object) to tokyo_tz for comparison
+        # This assumes it might have become naive UTC due to SQLAlchemy attribute handling
+        expected_dt_naive_utc = expected_ua_source.initially_acquired_datetime
+        if expected_dt_naive_utc.tzinfo is None:
+            expected_dt_aware_utc = expected_dt_naive_utc.replace(tzinfo=utc_zone)
+        else: # If it's somehow already aware, ensure it's UTC
+            expected_dt_aware_utc = expected_dt_naive_utc.astimezone(utc_zone)
+        expected_dt_tokyo_compare = expected_dt_aware_utc.astimezone(tokyo_tz)
+
+        # Convert actual datetime (from UserAchievement, sourced from DB naive UTC) to tokyo_tz
+        actual_dt_naive_utc = actual_ua.achieved_time
+        if actual_dt_naive_utc.tzinfo is None:
+            actual_dt_aware_utc = actual_dt_naive_utc.replace(tzinfo=utc_zone)
+        else: # Should not happen based on current _get_new_achievements logic
+            actual_dt_aware_utc = actual_dt_naive_utc.astimezone(utc_zone)
+        actual_dt_tokyo_compare = actual_dt_aware_utc.astimezone(tokyo_tz)
+
+        assert actual_dt_tokyo_compare == expected_dt_tokyo_compare
 
     session.close()
 

--- a/tests/test_modals.py
+++ b/tests/test_modals.py
@@ -1,5 +1,5 @@
 import zoneinfo
-from datetime import datetime
+from datetime import datetime, timedelta
 from textwrap import dedent
 from unittest import mock
 
@@ -13,7 +13,10 @@ from hikarie_bot.modals import (
     InitialMessage,
     PointGetMessage,
     RegistryMessage,
+    WeeklyMessage,  # Added WeeklyMessage
+    UserAchievement,  # Added UserAchievement
 )
+from hikarie_bot.models import User, Badge, UserBadge  # Added User, Badge, UserBadge
 
 
 def test_initial_message() -> None:
@@ -393,7 +396,7 @@ def test_achievement_message_6xx_taken_logic(temp_db: sessionmaker[Session]) -> 
     session.add(
         UserBadge(
             user_id="other_user",
-            user_info_raw_id="other_user",
+            user_info_raw_id="other_user", # Assuming user_info_raw_id can be same as user_id for simplicity
             badge_id=badge_6xx.id,
             initially_acquired_datetime=datetime(2024, 1, 1, 8, 0, 0, tzinfo=zoneinfo.ZoneInfo("Asia/Tokyo")),
             count=1,
@@ -415,3 +418,172 @@ def test_achievement_message_6xx_taken_logic(temp_db: sessionmaker[Session]) -> 
                     assert element["image_url"] == TAKEN_6XX_BADGE_IMAGE_URL
                     found = True
     assert found, "Should find taken icon for 6XX badge when another user has it"
+
+
+def test_get_new_achievements(temp_db: sessionmaker[Session]) -> None:
+    """Test the _get_new_achievements method of WeeklyMessage."""
+    session = temp_db()
+    initially_insert_badge_data(session=session) # Seed initial badge types and badges
+
+    # Define date range for the test
+    # Using timezone-aware datetimes as in other tests
+    tokyo_tz = zoneinfo.ZoneInfo("Asia/Tokyo")
+    report_date = datetime(2024, 7, 7, 0, 0, 0, tzinfo=tokyo_tz) # A Sunday
+    start_of_week = report_date - timedelta(days=7) # Previous Sunday
+    end_of_week = report_date - timedelta(microseconds=1) # End of Saturday
+
+    # Create Users
+    default_user_params = {
+        "level": 1,
+        "level_name": "Test Level 1",
+        "level_uped": False,
+        "point_to_next_level": 100,
+        "point_range_to_next_level": 200,
+        "current_level_point": 50,
+    }
+    user1 = User(id="user1", current_score=100, previous_score=50, update_datetime=report_date, **default_user_params)
+    user2 = User(id="user2", current_score=200, previous_score=150, update_datetime=report_date, **default_user_params)
+    session.add_all([user1, user2])
+    session.commit() # Users must exist before UserBadge references them
+
+    # Create Badges (ensure some exist, or use ones from initially_insert_badge_data)
+    # Using high badge IDs to avoid conflicts with initially_insert_badge_data
+    test_badge_ids = [5001, 5002, 5003, 5004, 5005, 5006, 5007]
+    badges_to_add = []
+    for i, bid in enumerate(test_badge_ids):
+        badges_to_add.append(
+            Badge(id=bid, badge_type_id=1, message=f"Message for Badge {bid}", condition=f"Cond {bid}", score=10, level=1)
+        )
+    session.add_all(badges_to_add)
+    session.commit()
+
+    # Create UserBadge records
+    # These should be returned
+    ub1_time = start_of_week + timedelta(days=1) # Within week
+    ub1 = UserBadge(user_id="user1", user_info_raw_id="user1_raw1", badge_id=test_badge_ids[0], initially_acquired_datetime=ub1_time, last_acquired_datetime=ub1_time, count=1)
+    ub2_time = start_of_week + timedelta(days=2) # Within week, later than ub1
+    ub2 = UserBadge(user_id="user2", user_info_raw_id="user2_raw1", badge_id=test_badge_ids[1], initially_acquired_datetime=ub2_time, last_acquired_datetime=ub2_time, count=1)
+
+    # These should NOT be returned
+    ub3_time = start_of_week - timedelta(days=1) # Before week
+    ub3 = UserBadge(user_id="user1", user_info_raw_id="user1_raw2", badge_id=test_badge_ids[2], initially_acquired_datetime=ub3_time, last_acquired_datetime=ub3_time, count=1)
+    ub4_time = end_of_week + timedelta(days=1) # After week
+    # Using test_badge_ids[0] for ub4 to check if it's correctly excluded even if badge_id is same as a valid one for another user
+    ub4 = UserBadge(user_id="user2", user_info_raw_id="user2_raw2", badge_id=test_badge_ids[0], initially_acquired_datetime=ub4_time, last_acquired_datetime=ub4_time, count=1)
+
+    # Test `initially_acquired_datetime` logic vs `last_acquired_datetime`
+    ub5_initial_time = start_of_week - timedelta(days=5) # Initial acquire before week
+    ub5_last_time = start_of_week + timedelta(days=3)    # Last acquire within week
+    ub5 = UserBadge(user_id="user1", user_info_raw_id="user1_raw3", badge_id=test_badge_ids[3], initially_acquired_datetime=ub5_initial_time, last_acquired_datetime=ub5_last_time, count=2)
+
+    # More UserBadges to test limit and ordering
+    # ub1 and ub2 are already defined using test_badge_ids[0] and test_badge_ids[1]
+    # Let's use remaining test_badge_ids for the limit test items.
+    # We need 7 candidates in total to test the limit of 5.
+    # ub1 and ub2 are 2 candidates. We need 5 more.
+
+    user_badges_to_add = [ub1, ub2, ub3, ub4, ub5] # ub1, ub2 are candidates; ub3, ub4, ub5 are not.
+
+    # 7 items that *should* be candidates if not for the limit
+    candidate_user_badges = []
+    # We already have ub1 (day 1) and ub2 (day 2) as candidates.
+    # Add 5 more candidates to have a total of 7.
+    # These will use test_badge_ids[2] through test_badge_ids[6]
+
+    # Candidate 1: ub1 (day 1, badge 5001)
+    # Candidate 2: ub2 (day 2, badge 5002)
+
+    # Candidate 3 (day 0, badge 5003) - should be earliest if included in sorting
+    cand3_time = start_of_week + timedelta(days=0, hours=12)
+    cand3 = UserBadge(user_id="user1", user_info_raw_id="user1_cand3", badge_id=test_badge_ids[2], initially_acquired_datetime=cand3_time, count=1)
+    candidate_user_badges.append(cand3)
+
+    # Candidate 4 (day 3, badge 5004)
+    cand4_time = start_of_week + timedelta(days=3, hours=12)
+    cand4 = UserBadge(user_id="user2", user_info_raw_id="user2_cand4", badge_id=test_badge_ids[3], initially_acquired_datetime=cand4_time, count=1)
+    candidate_user_badges.append(cand4)
+
+    # Candidate 5 (day 4, badge 5005)
+    cand5_time = start_of_week + timedelta(days=4, hours=12)
+    cand5 = UserBadge(user_id="user1", user_info_raw_id="user1_cand5", badge_id=test_badge_ids[4], initially_acquired_datetime=cand5_time, count=1)
+    candidate_user_badges.append(cand5)
+
+    # Candidate 6 (day 5, badge 5006)
+    cand6_time = start_of_week + timedelta(days=5, hours=12)
+    cand6 = UserBadge(user_id="user2", user_info_raw_id="user2_cand6", badge_id=test_badge_ids[5], initially_acquired_datetime=cand6_time, count=1)
+    candidate_user_badges.append(cand6)
+
+    # Candidate 7 (day 6, badge 5007) - should be latest
+    cand7_time = start_of_week + timedelta(days=6, hours=12)
+    cand7 = UserBadge(user_id="user1", user_info_raw_id="user1_cand7", badge_id=test_badge_ids[6], initially_acquired_datetime=cand7_time, count=1)
+    candidate_user_badges.append(cand7)
+
+    # Add ub1, ub2 to candidate_user_badges list for sorting later
+    candidate_user_badges.extend([ub1, ub2])
+
+    user_badges_to_add.extend([cand3, cand4, cand5, cand6, cand7])
+    session.add_all(user_badges_to_add)
+    session.commit()
+
+    # Instantiate WeeklyMessage
+    # Note: WeeklyMessage constructor calls _get_new_achievements itself.
+    # For isolated testing, we might call it directly, but here we test integration.
+    weekly_message = WeeklyMessage(session=session, report_date=report_date)
+
+    # Call the method (it's also called in __init__, but we can call again for clarity or specific params)
+    new_achievements = weekly_message._get_new_achievements(session, start_of_week, end_of_week)
+
+    # Assertions
+    assert len(new_achievements) == 5, "Should return 5 achievements due to limit"
+
+    for ach in new_achievements:
+        assert isinstance(ach, UserAchievement), "All items should be UserAchievement instances"
+        # Make ach.achieved_time offset-aware for comparison if it's naive
+        # Assuming ach.achieved_time from DB is naive but represents Tokyo time
+        achieved_time_aware = ach.achieved_time.replace(tzinfo=tokyo_tz)
+        assert start_of_week <= achieved_time_aware <= end_of_week, "Achievement time should be within the week"
+
+    # Check sorting (descending by achieved_time)
+    for i in range(len(new_achievements) - 1):
+        assert new_achievements[i].achieved_time >= new_achievements[i+1].achieved_time, "Achievements should be sorted descending by time"
+
+    # Check specific items that should NOT be there
+    returned_tuples = {(ach.user_id, ach.badge_id) for ach in new_achievements}
+    # ub3 was badge_id=test_badge_ids[2] (5003)
+    assert ("user1", test_badge_ids[2]) not in returned_tuples or \
+           any(ach.user_id == "user1" and ach.badge_id == test_badge_ids[2] and ach.achieved_time == cand3_time for ach in new_achievements), \
+           "ub3 (before week) should not be returned unless it's the valid cand3"
+
+    # ub4 was badge_id=test_badge_ids[0] (5001) with user2, time after week
+    assert not any(ach.user_id == "user2" and ach.badge_id == test_badge_ids[0] and ach.achieved_time == ub4_time for ach in new_achievements), \
+           "ub4 (after week) should not be returned"
+
+    # ub5 was badge_id=test_badge_ids[3] (5004) with initial acquire before week
+    assert not any(ach.user_id == "user1" and ach.badge_id == test_badge_ids[3] and ach.achieved_time == ub5_initial_time for ach in new_achievements), \
+           "ub5 (initial acquire before week) should not be returned"
+
+
+    # Check that the top 5 by initially_acquired_datetime are returned
+    # These are the last 5 from `candidate_badges` as they have the latest times
+    all_candidates_in_week = sorted(
+        [ub for ub in candidate_user_badges if start_of_week <= ub.initially_acquired_datetime <= end_of_week],
+        key=lambda x: x.initially_acquired_datetime,
+        reverse=True
+    )
+    expected_top_5_source = all_candidates_in_week[:5]
+
+    for i in range(5):
+        expected_ua_source = expected_top_5_source[i]
+        actual_ua = new_achievements[i]
+
+        assert actual_ua.user_id == expected_ua_source.user_id
+        assert actual_ua.badge_id == expected_ua_source.badge_id
+        # Query badge message for verification, as it's not in UserBadge directly
+        badge_msg_obj = session.get(Badge, expected_ua_source.badge_id) # Get existing badge
+        assert badge_msg_obj is not None
+        assert actual_ua.message == badge_msg_obj.message
+        assert actual_ua.achieved_time == expected_ua_source.initially_acquired_datetime
+
+    session.close()
+
+# Keep existing tests below this line

--- a/tests/test_modals.py
+++ b/tests/test_modals.py
@@ -1,5 +1,5 @@
 import zoneinfo
-from datetime import datetime, timedelta # Added timedelta
+from datetime import datetime, timedelta  # Added timedelta
 from textwrap import dedent
 from unittest import mock
 
@@ -13,10 +13,10 @@ from hikarie_bot.modals import (
     InitialMessage,
     PointGetMessage,
     RegistryMessage,
-    WeeklyMessage,      # Added WeeklyMessage
-    UserAchievement,    # Added UserAchievement
+    UserAchievement,  # Added UserAchievement
+    WeeklyMessage,  # Added WeeklyMessage
 )
-from hikarie_bot.models import User, Badge, UserBadge # Added User, Badge, UserBadge
+from hikarie_bot.models import Badge, User, UserBadge  # Added User, Badge, UserBadge
 
 
 def test_initial_message() -> None:
@@ -358,7 +358,7 @@ def test_achievement_message_type_6(temp_db: sessionmaker[Session]) -> None:
 @mock.patch("hikarie_bot.modals.BADGE_TYPES_TO_CHECK", [6])
 def test_achievement_message_6xx_taken_logic(temp_db: sessionmaker[Session]) -> None:
     """Test 6XX badge logic: taken icon if any user has it, not achieved if none."""
-    from hikarie_bot.models import Badge, UserBadge # Local import for this test
+    from hikarie_bot.models import Badge, UserBadge  # Local import for this test
 
     session = temp_db()
     initially_insert_badge_data(session=session)
@@ -376,6 +376,7 @@ def test_achievement_message_6xx_taken_logic(temp_db: sessionmaker[Session]) -> 
                     f"【{badge_6xx.message}】"
                 ):
                     from hikarie_bot.constants import NOT_ACHIEVED_BADGE_IMAGE_URL
+
                     assert element["image_url"] == NOT_ACHIEVED_BADGE_IMAGE_URL
                     found = True
     assert found, "Should find not achieved icon for 6XX badge when no user has it"
@@ -401,12 +402,13 @@ def test_achievement_message_6xx_taken_logic(temp_db: sessionmaker[Session]) -> 
                     f"【{badge_6xx.message}】"
                 ):
                     from hikarie_bot.constants import TAKEN_6XX_BADGE_IMAGE_URL
+
                     assert element["image_url"] == TAKEN_6XX_BADGE_IMAGE_URL
                     found = True
     assert found, "Should find taken icon for 6XX badge when another user has it"
 
 
-def test_get_new_achievements(temp_db: sessionmaker[Session]) -> None:
+def test_get_new_achievements(temp_db: sessionmaker[Session]) -> None:  # noqa: PLR0912, PLR0915
     """Test the _get_new_achievements method of WeeklyMessage."""
     session = temp_db()
     initially_insert_badge_data(session=session)
@@ -417,8 +419,12 @@ def test_get_new_achievements(temp_db: sessionmaker[Session]) -> None:
     end_of_week = report_date - timedelta(microseconds=1)
 
     default_user_params = {
-        "level": 1, "level_name": "Test Level 1", "level_uped": False,
-        "point_to_next_level": 100, "point_range_to_next_level": 200, "current_level_point": 50,
+        "level": 1,
+        "level_name": "Test Level 1",
+        "level_uped": False,
+        "point_to_next_level": 100,
+        "point_range_to_next_level": 200,
+        "current_level_point": 50,
     }
     user1 = User(id="user1", current_score=100, previous_score=50, update_datetime=report_date, **default_user_params)
     user2 = User(id="user2", current_score=200, previous_score=150, update_datetime=report_date, **default_user_params)
@@ -426,45 +432,110 @@ def test_get_new_achievements(temp_db: sessionmaker[Session]) -> None:
     session.commit()
 
     test_badge_ids = [5001, 5002, 5003, 5004, 5005, 5006, 5007]
-    badges_to_add = []
-    for bid in test_badge_ids:
-        badges_to_add.append(
-            Badge(id=bid, badge_type_id=1, message=f"Message for Badge {bid}", condition=f"Cond {bid}", score=10, level=1)
-        )
+    badges_to_add = [
+        Badge(id=bid, badge_type_id=1, message=f"Message for Badge {bid}", condition=f"Cond {bid}", score=10, level=1)
+        for bid in test_badge_ids
+    ]
+
     session.add_all(badges_to_add)
     session.commit()
 
     ub1_time = start_of_week + timedelta(days=1)
-    ub1 = UserBadge(user_id="user1", user_info_raw_id="user1_raw1", badge_id=test_badge_ids[0], initially_acquired_datetime=ub1_time, last_acquired_datetime=ub1_time, count=1)
+    ub1 = UserBadge(
+        user_id="user1",
+        user_info_raw_id="user1_raw1",
+        badge_id=test_badge_ids[0],
+        initially_acquired_datetime=ub1_time,
+        last_acquired_datetime=ub1_time,
+        count=1,
+    )
     ub2_time = start_of_week + timedelta(days=2)
-    ub2 = UserBadge(user_id="user2", user_info_raw_id="user2_raw1", badge_id=test_badge_ids[1], initially_acquired_datetime=ub2_time, last_acquired_datetime=ub2_time, count=1)
+    ub2 = UserBadge(
+        user_id="user2",
+        user_info_raw_id="user2_raw1",
+        badge_id=test_badge_ids[1],
+        initially_acquired_datetime=ub2_time,
+        last_acquired_datetime=ub2_time,
+        count=1,
+    )
 
     ub3_time = start_of_week - timedelta(days=1)
-    ub3 = UserBadge(user_id="user1", user_info_raw_id="user1_raw2", badge_id=test_badge_ids[2], initially_acquired_datetime=ub3_time, last_acquired_datetime=ub3_time, count=1)
+    ub3 = UserBadge(
+        user_id="user1",
+        user_info_raw_id="user1_raw2",
+        badge_id=test_badge_ids[2],
+        initially_acquired_datetime=ub3_time,
+        last_acquired_datetime=ub3_time,
+        count=1,
+    )
     ub4_time = end_of_week + timedelta(days=1)
-    ub4 = UserBadge(user_id="user2", user_info_raw_id="user2_raw2", badge_id=test_badge_ids[0], initially_acquired_datetime=ub4_time, last_acquired_datetime=ub4_time, count=1)
+    ub4 = UserBadge(
+        user_id="user2",
+        user_info_raw_id="user2_raw2",
+        badge_id=test_badge_ids[0],
+        initially_acquired_datetime=ub4_time,
+        last_acquired_datetime=ub4_time,
+        count=1,
+    )
 
     ub5_initial_time = start_of_week - timedelta(days=5)
     ub5_last_time = start_of_week + timedelta(days=3)
-    ub5 = UserBadge(user_id="user1", user_info_raw_id="user1_raw3", badge_id=test_badge_ids[3], initially_acquired_datetime=ub5_initial_time, last_acquired_datetime=ub5_last_time, count=2)
+    ub5 = UserBadge(
+        user_id="user1",
+        user_info_raw_id="user1_raw3",
+        badge_id=test_badge_ids[3],
+        initially_acquired_datetime=ub5_initial_time,
+        last_acquired_datetime=ub5_last_time,
+        count=2,
+    )
 
     user_badges_to_add = [ub1, ub2, ub3, ub4, ub5]
     candidate_user_badges = []
 
     cand3_time = start_of_week + timedelta(days=0, hours=12)
-    cand3 = UserBadge(user_id="user1", user_info_raw_id="user1_cand3", badge_id=test_badge_ids[2], initially_acquired_datetime=cand3_time, count=1)
+    cand3 = UserBadge(
+        user_id="user1",
+        user_info_raw_id="user1_cand3",
+        badge_id=test_badge_ids[2],
+        initially_acquired_datetime=cand3_time,
+        count=1,
+    )
     candidate_user_badges.append(cand3)
     cand4_time = start_of_week + timedelta(days=3, hours=12)
-    cand4 = UserBadge(user_id="user2", user_info_raw_id="user2_cand4", badge_id=test_badge_ids[3], initially_acquired_datetime=cand4_time, count=1)
+    cand4 = UserBadge(
+        user_id="user2",
+        user_info_raw_id="user2_cand4",
+        badge_id=test_badge_ids[3],
+        initially_acquired_datetime=cand4_time,
+        count=1,
+    )
     candidate_user_badges.append(cand4)
     cand5_time = start_of_week + timedelta(days=4, hours=12)
-    cand5 = UserBadge(user_id="user1", user_info_raw_id="user1_cand5", badge_id=test_badge_ids[4], initially_acquired_datetime=cand5_time, count=1)
+    cand5 = UserBadge(
+        user_id="user1",
+        user_info_raw_id="user1_cand5",
+        badge_id=test_badge_ids[4],
+        initially_acquired_datetime=cand5_time,
+        count=1,
+    )
     candidate_user_badges.append(cand5)
     cand6_time = start_of_week + timedelta(days=5, hours=12)
-    cand6 = UserBadge(user_id="user2", user_info_raw_id="user2_cand6", badge_id=test_badge_ids[5], initially_acquired_datetime=cand6_time, count=1)
+    cand6 = UserBadge(
+        user_id="user2",
+        user_info_raw_id="user2_cand6",
+        badge_id=test_badge_ids[5],
+        initially_acquired_datetime=cand6_time,
+        count=1,
+    )
     candidate_user_badges.append(cand6)
     cand7_time = start_of_week + timedelta(days=6, hours=12)
-    cand7 = UserBadge(user_id="user1", user_info_raw_id="user1_cand7", badge_id=test_badge_ids[6], initially_acquired_datetime=cand7_time, count=1)
+    cand7 = UserBadge(
+        user_id="user1",
+        user_info_raw_id="user1_cand7",
+        badge_id=test_badge_ids[6],
+        initially_acquired_datetime=cand7_time,
+        count=1,
+    )
     candidate_user_badges.append(cand7)
 
     candidate_user_badges.extend([ub1, ub2])
@@ -473,35 +544,64 @@ def test_get_new_achievements(temp_db: sessionmaker[Session]) -> None:
     session.commit()
 
     weekly_message = WeeklyMessage(session=session, report_date=report_date)
-    new_achievements = weekly_message._get_new_achievements(session, start_of_week, end_of_week)
+    new_achievements = weekly_message._get_new_achievements(session, start_of_week, end_of_week)  # noqa: SLF001
 
     assert len(new_achievements) == 5, "Should return 5 achievements due to limit"
 
-    utc_zone = zoneinfo.ZoneInfo("UTC") # Define UTC zone for convenience
+    utc_zone = zoneinfo.ZoneInfo("UTC")  # Define UTC zone for convenience
 
     for ach in new_achievements:
         assert isinstance(ach, UserAchievement), "All items should be UserAchievement instances"
-        ach_time_to_compare = ach.achieved_time # This is naive UTC from DB
-        if ach_time_to_compare.tzinfo is None: # Should always be naive
+        ach_time_to_compare = ach.achieved_time  # This is naive UTC from DB
+        if ach_time_to_compare.tzinfo is None:  # Should always be naive
             ach_time_utc_aware = ach_time_to_compare.replace(tzinfo=utc_zone)
             ach_time_to_compare = ach_time_utc_aware.astimezone(tokyo_tz)
-        else: # Should not happen based on current _get_new_achievements logic
+        else:  # Should not happen based on current _get_new_achievements logic
             ach_time_to_compare = ach_time_to_compare.astimezone(tokyo_tz)
 
-        assert start_of_week <= ach_time_to_compare <= end_of_week, \
+        assert start_of_week <= ach_time_to_compare <= end_of_week, (
             f"Achievement time {ach_time_to_compare} (original: {ach.achieved_time}) should be within the week [{start_of_week}, {end_of_week}]"
+        )
 
     for i in range(len(new_achievements) - 1):
-        assert new_achievements[i].achieved_time >= new_achievements[i+1].achieved_time, "Achievements should be sorted descending by time"
+        assert new_achievements[i].achieved_time >= new_achievements[i + 1].achieved_time, (
+            "Achievements should be sorted descending by time"
+        )
 
     returned_tuples = {(ach.user_id, ach.badge_id) for ach in new_achievements}
-    assert ("user1", test_badge_ids[2]) not in returned_tuples or \
-           any(ach.user_id == "user1" and ach.badge_id == test_badge_ids[2] and (ach.achieved_time.replace(tzinfo=utc_zone).astimezone(tokyo_tz) if ach.achieved_time.tzinfo is None else ach.achieved_time.astimezone(tokyo_tz)) == cand3_time for ach in new_achievements), \
-           "ub3 (before week) should not be returned unless it's the valid cand3"
-    assert not any(ach.user_id == "user2" and ach.badge_id == test_badge_ids[0] and (ach.achieved_time.replace(tzinfo=utc_zone).astimezone(tokyo_tz) if ach.achieved_time.tzinfo is None else ach.achieved_time.astimezone(tokyo_tz)) == ub4_time for ach in new_achievements), \
-           "ub4 (after week) should not be returned"
-    assert not any(ach.user_id == "user1" and ach.badge_id == test_badge_ids[3] and (ach.achieved_time.replace(tzinfo=utc_zone).astimezone(tokyo_tz) if ach.achieved_time.tzinfo is None else ach.achieved_time.astimezone(tokyo_tz)) == ub5_initial_time for ach in new_achievements), \
-           "ub5 (initial acquire before week) should not be returned"
+    assert ("user1", test_badge_ids[2]) not in returned_tuples or any(
+        ach.user_id == "user1"
+        and ach.badge_id == test_badge_ids[2]
+        and (
+            ach.achieved_time.replace(tzinfo=utc_zone).astimezone(tokyo_tz)
+            if ach.achieved_time.tzinfo is None
+            else ach.achieved_time.astimezone(tokyo_tz)
+        )
+        == cand3_time
+        for ach in new_achievements
+    ), "ub3 (before week) should not be returned unless it's the valid cand3"
+    assert not any(
+        ach.user_id == "user2"
+        and ach.badge_id == test_badge_ids[0]
+        and (
+            ach.achieved_time.replace(tzinfo=utc_zone).astimezone(tokyo_tz)
+            if ach.achieved_time.tzinfo is None
+            else ach.achieved_time.astimezone(tokyo_tz)
+        )
+        == ub4_time
+        for ach in new_achievements
+    ), "ub4 (after week) should not be returned"
+    assert not any(
+        ach.user_id == "user1"
+        and ach.badge_id == test_badge_ids[3]
+        and (
+            ach.achieved_time.replace(tzinfo=utc_zone).astimezone(tokyo_tz)
+            if ach.achieved_time.tzinfo is None
+            else ach.achieved_time.astimezone(tokyo_tz)
+        )
+        == ub5_initial_time
+        for ach in new_achievements
+    ), "ub5 (initial acquire before week) should not be returned"
 
     filtered_candidates = []
     # utc_zone is defined above in the first loop
@@ -511,7 +611,7 @@ def test_get_new_achievements(temp_db: sessionmaker[Session]) -> None:
 
         if dt_potentially_naive_utc.tzinfo is None:
             dt_aware_utc = dt_potentially_naive_utc.replace(tzinfo=utc_zone)
-        else: # If it's somehow already aware, ensure it's UTC before converting to Tokyo
+        else:  # If it's somehow already aware, ensure it's UTC before converting to Tokyo
             dt_aware_utc = dt_potentially_naive_utc.astimezone(utc_zone)
 
         dt_tokyo_aware = dt_aware_utc.astimezone(tokyo_tz)
@@ -521,10 +621,12 @@ def test_get_new_achievements(temp_db: sessionmaker[Session]) -> None:
 
     all_candidates_in_week = sorted(
         filtered_candidates,
-        key=lambda x: (x.initially_acquired_datetime.replace(tzinfo=utc_zone).astimezone(tokyo_tz)
-                       if x.initially_acquired_datetime.tzinfo is None
-                       else x.initially_acquired_datetime.astimezone(tokyo_tz)),
-        reverse=True
+        key=lambda x: (
+            x.initially_acquired_datetime.replace(tzinfo=utc_zone).astimezone(tokyo_tz)
+            if x.initially_acquired_datetime.tzinfo is None
+            else x.initially_acquired_datetime.astimezone(tokyo_tz)
+        ),
+        reverse=True,
     )
     expected_top_5_source = all_candidates_in_week[:5]
 
@@ -544,7 +646,7 @@ def test_get_new_achievements(temp_db: sessionmaker[Session]) -> None:
         expected_dt_naive_utc = expected_ua_source.initially_acquired_datetime
         if expected_dt_naive_utc.tzinfo is None:
             expected_dt_aware_utc = expected_dt_naive_utc.replace(tzinfo=utc_zone)
-        else: # If it's somehow already aware, ensure it's UTC
+        else:  # If it's somehow already aware, ensure it's UTC
             expected_dt_aware_utc = expected_dt_naive_utc.astimezone(utc_zone)
         expected_dt_tokyo_compare = expected_dt_aware_utc.astimezone(tokyo_tz)
 
@@ -552,12 +654,13 @@ def test_get_new_achievements(temp_db: sessionmaker[Session]) -> None:
         actual_dt_naive_utc = actual_ua.achieved_time
         if actual_dt_naive_utc.tzinfo is None:
             actual_dt_aware_utc = actual_dt_naive_utc.replace(tzinfo=utc_zone)
-        else: # Should not happen based on current _get_new_achievements logic
+        else:  # Should not happen based on current _get_new_achievements logic
             actual_dt_aware_utc = actual_dt_naive_utc.astimezone(utc_zone)
         actual_dt_tokyo_compare = actual_dt_aware_utc.astimezone(tokyo_tz)
 
         assert actual_dt_tokyo_compare == expected_dt_tokyo_compare
 
     session.close()
+
 
 # Keep existing tests below this line


### PR DESCRIPTION
The weekly report's "newly unlocked achievements" section was incorrectly displaying achievements based on any `Achievement.achieved_time` within the reporting week. This meant that if you re-triggered the conditions for an already earned badge, it would show up as "new" again.

This commit changes the `_get_new_achievements` method in `WeeklyMessage` (in `hikarie_bot/modals.py`) to query the `UserBadge` table and use the `initially_acquired_datetime` field. This ensures that only badges truly acquired for the first time during the reporting week are listed as new.

A new pytest test, `test_get_new_achievements`, has been added to `tests/test_modals.py`. This test verifies:
- Correct filtering by `initially_acquired_datetime` within the week.
- Badges acquired outside the week are excluded.
- The `last_acquired_datetime` is not mistakenly used.
- The limit of 5 new achievements is respected.
- Results are ordered by `initially_acquired_datetime` descending.