### PR TITLE
fix(slack_helper): increase sleep duration to comply with API rate limits

### DIFF
--- a/hikarie_bot/_version.py
+++ b/hikarie_bot/_version.py
@@ -17,5 +17,5 @@ __version__: str
 __version_tuple__: VERSION_TUPLE
 version_tuple: VERSION_TUPLE
 
-__version__ = version = '0.1.dev175+g52c5e52.d20250602'
-__version_tuple__ = version_tuple = (0, 1, 'dev175', 'g52c5e52.d20250602')
+__version__ = version = '0.1.dev176+gc9410aa.d20250723'
+__version_tuple__ = version_tuple = (0, 1, 'dev176', 'gc9410aa.d20250723')

--- a/hikarie_bot/slack_helper.py
+++ b/hikarie_bot/slack_helper.py
@@ -357,7 +357,7 @@ async def get_messages(app: AsyncApp) -> list[dict[str, Any]]:
             oldest="1651363200",  # 2022-05-01 00:00:00
         )
         messages += _messages.get("messages", [])
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(1)  # Tier 3: 50+ requests per minute
     return messages
 
 
@@ -384,5 +384,5 @@ async def retrieve_thread_messages(app: AsyncApp, message: dict[str, Any]) -> li
         logger.info(f"loading thread. latest message: {jst_message_datetime}")
         _thread_messages = await app.client.conversations_replies(channel=OUTPUT_CHANNEL, ts=message["ts"], limit=100)
         thread_messages += _thread_messages.get("messages", [])
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(1)  # Tier 3: 50+ requests per minute
     return thread_messages


### PR DESCRIPTION
Updated the sleep duration in `get_messages` and `retrieve_thread_messages` functions from 0.1 seconds to 1 second to adhere to Tier 3 API rate limits of 50+ requests per minute.